### PR TITLE
Add minimal MCP-OS prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,82 @@
 # MCP-OS
+
+The **Model Context Protocol Operating System (MCP-OS)** is a concept for a post‑application computing platform. Instead of bundling discrete programs with fixed user interfaces, MCP-OS delegates most logic and UI generation to a large language model. A lightweight shell running on the device gathers user actions and context, sends them to the model, and renders the model's declarative response.
+
+## System architecture
+
+MCP-OS consists of three key pieces:
+
+1. **MCP-Kernel** – the large language model that interprets requests and produces responses.
+2. **MCP-Shell** – a minimal renderer that captures user input, formats protocol requests, and displays the returned UI tree.
+3. **Model Context Protocol** – a structured message format defining how the shell and kernel communicate.
+
+The shell packages each user action and the current view state into an MCP request. The kernel reasons about this context and replies with a new UI description. The shell simply renders that description, forming a continuous feedback loop.
+
+## Model Context Protocol
+
+A minimal request example:
+
+```json
+{
+  "protocol_version": "1.0",
+  "session_id": "sid_example_1234",
+  "user_context": { "name": "Alex" },
+  "current_ui_state": {
+    "view_id": "view_home",
+    "component_tree_hash": "abcd1234"
+  },
+  "event": {
+    "type": "click",
+    "target": { "component_id": "desktop_icon_documents" }
+  }
+}
+```
+
+A response from the kernel might look like:
+
+```json
+{
+  "protocol_version": "1.0",
+  "session_id": "sid_example_1234",
+  "directive": "REPLACE_VIEW",
+  "new_ui_state": {
+    "view_id": "view_documents",
+    "component_tree": {
+      "component": "Window",
+      "children": [ { "component": "ListView" } ]
+    }
+  }
+}
+```
+
+## Example workflow
+
+1. The user interacts with the shell, for instance by clicking an icon.
+2. The shell emits an MCP request describing that event and the current view.
+3. The kernel analyzes the request and produces an MCP response describing the next view.
+4. The shell renders the new view and awaits further input.
+
+## Challenges
+
+Achieving practical performance and consistency with a model‑driven OS presents challenges around latency, state management, cost, and security. The protocol is intentionally simple to enable experimentation with these issues while keeping the renderer lightweight.
+
+
+## Reference implementation
+
+A small command-line prototype demonstrates the MCP loop.
+It consists of three modules under the `mcp/` package:
+
+- `protocol.py` – definitions for request and response structures
+- `kernel.py` – a trivial kernel that generates example views
+- `shell.py` – an interactive renderer that prints UI trees and sends events
+
+### Running the demo
+
+```
+python -m mcp.shell
+```
+
+The shell prints a simple desktop containing a Documents icon.
+Enter the component id you wish to click (for example `desktop_icon_documents`).
+The shell sends an MCP request to the kernel and renders the
+returned view description.

--- a/mcp/kernel.py
+++ b/mcp/kernel.py
@@ -1,0 +1,62 @@
+"""Simplistic MCP-Kernel stub."""
+import random
+from typing import Dict, Any
+
+from .protocol import MCPRequest, MCPResponse, hash_tree
+
+
+class MCPKernel:
+    def handle_request(self, req: MCPRequest) -> MCPResponse:
+        """Generate a trivial response based on the click target."""
+        # Use random example UI elements
+        if req.event.target.get("component_id") == "desktop_icon_documents":
+            new_view = {
+                "component": "Window",
+                "properties": {"title": "Documents"},
+                "children": [
+                    {
+                        "component": "ListView",
+                        "children": [
+                            {
+                                "component": "ListItem",
+                                "properties": {
+                                    "id": "file_report",
+                                    "label": "Report.docx",
+                                },
+                            },
+                            {
+                                "component": "ListItem",
+                                "properties": {
+                                    "id": "folder_projects",
+                                    "label": "Projects/",
+                                },
+                            },
+                        ],
+                    }
+                ],
+            }
+        else:
+            # Default generic window
+            new_view = {
+                "component": "Window",
+                "properties": {"title": "Home"},
+                "children": [
+                    {
+                        "component": "Text",
+                        "properties": {
+                            "content": f"Clicked {req.event.target.get('component_id')}",
+                        },
+                    }
+                ],
+            }
+
+        return MCPResponse(
+            protocol_version=req.protocol_version,
+            session_id=req.session_id,
+            directive="REPLACE_VIEW",
+            new_ui_state={
+                "view_id": f"view_{random.randint(1000,9999)}",
+                "component_tree": new_view,
+                "component_tree_hash": hash_tree(new_view),
+            },
+        )

--- a/mcp/protocol.py
+++ b/mcp/protocol.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional
+import hashlib
+
+
+def hash_tree(tree: Dict[str, Any]) -> str:
+    """Return a simple hash for a dictionary representing a UI tree."""
+    return hashlib.md5(repr(tree).encode()).hexdigest()[:8]
+
+
+@dataclass
+class Event:
+    type: str
+    target: Dict[str, Any]
+    payload: Optional[Dict[str, Any]] = None
+
+
+@dataclass
+class MCPRequest:
+    protocol_version: str
+    session_id: str
+    user_context: Dict[str, Any]
+    current_ui_state: Dict[str, Any]
+    event: Event
+
+
+@dataclass
+class MCPResponse:
+    protocol_version: str
+    session_id: str
+    directive: str
+    new_ui_state: Dict[str, Any]

--- a/mcp/shell.py
+++ b/mcp/shell.py
@@ -1,0 +1,66 @@
+"""Minimal MCP-Shell command-line renderer."""
+import json
+import uuid
+
+from .protocol import Event, MCPRequest
+from .kernel import MCPKernel
+
+
+def pretty_print(tree, indent=0):
+    prefix = ' ' * indent
+    component = tree.get('component')
+    props = tree.get('properties', {})
+    print(f"{prefix}{component}: {props}")
+    for child in tree.get('children', []):
+        pretty_print(child, indent + 2)
+
+
+def main():
+    kernel = MCPKernel()
+    session_id = f"sid_{uuid.uuid4().hex[:8]}"
+
+    current_ui_state = {
+        "view_id": "view_home",
+        "component_tree": {
+            "component": "Desktop",
+            "children": [
+                {
+                    "component": "Icon",
+                    "properties": {
+                        "id": "desktop_icon_documents",
+                        "label": "Documents",
+                    },
+                },
+                {
+                    "component": "Icon",
+                    "properties": {
+                        "id": "desktop_icon_other",
+                        "label": "Other",
+                    },
+                },
+            ],
+        },
+    }
+
+    while True:
+        print("\nCurrent UI:")
+        pretty_print(current_ui_state["component_tree"])
+        target = input("\nEnter component id to click (or 'quit'): ")
+        if target == 'quit':
+            break
+        event = Event(type="click", target={"component_id": target})
+        req = MCPRequest(
+            protocol_version="1.0",
+            session_id=session_id,
+            user_context={"name": "Alex"},
+            current_ui_state={
+                "view_id": current_ui_state["view_id"],
+                "component_tree_hash": "",
+            },
+            event=event,
+        )
+        resp = kernel.handle_request(req)
+        current_ui_state = resp.new_ui_state
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a reference MCP-OS prototype in Python
- define protocol classes and a stub kernel
- add a CLI shell that renders a simple UI loop
- document running the demo

## Testing
- `python -m py_compile mcp/*.py`
- Ran `python -m mcp.shell` interactively

------
https://chatgpt.com/codex/tasks/task_e_685a8255bf7c8327b68249d7a37d100d